### PR TITLE
Release v1.0.0 MVP stabilization

### DIFF
--- a/.github/workflows/pr-smoke-tests.yml
+++ b/.github/workflows/pr-smoke-tests.yml
@@ -21,6 +21,16 @@ jobs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
       docs_changed: ${{ steps.detect.outputs.docs_changed }}
 
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect docs-only changes
+        id: detect
+        uses: ./.github/actions/detect-docs-only
+
 
   controlled-smoke-tests:
     name: Controlled smoke tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,372 +1,180 @@
 # CONTRIBUTING
 
-## Overview
+This project is a JetBrains IDE plugin for showing CI status in PyCharm/IntelliJ. It supports GitHub commit-status polling and direct Jenkins polling, with optional experimental Keycloak/OIDC session recovery for Jenkins setups that require a browser login.
 
-The plugin monitors Jenkins CI status and handles authentication automatically when possible.
+## Project Layout
 
-Core flow:
+- `src/main/kotlin/com/damorosodaragona/jenkinsnotifier/`: Kotlin production code.
+- `src/main/resources/META-INF/plugin.xml`: JetBrains plugin registration for settings, services, startup activity, tool window, and notifications.
+- `src/test/kotlin/com/damorosodaragona/jenkinsnotifier/`: unit, infrastructure, and smoke-oriented tests.
+- `src/test/resources/jenkins-smoke/`: disposable Jenkins resources for controlled smoke tests.
+- `.github/workflows/`: CI, plugin build, smoke test, and release workflows.
+- `scripts/`: local helper scripts, currently focused on PIT mutation testing.
 
-```
-Polling → Jenkins API → Auth check → Auto-login → (optional) Notification → UI update
-```
+## Main Components
 
----
+- `CiStatusSettings`: project-level persisted settings and Password Safe integration.
+- `CiStatusConfigurable`: Settings UI under `Settings | Tools | Jenkins CI Notifier`.
+- `CiStatusStartupActivity`: startup wiring, polling loop, notification decisions, and refresh events.
+- `CiStatusToolWindowFactory`: Jenkins CI tool window, job tree, build details, stages, artifacts, and preview actions.
+- `JenkinsStatusClient`: Jenkins API access, job discovery, build lookup, stages, artifacts, and diagnostics helpers.
+- `GitHubStatusClient`: GitHub commit-status lookup.
+- `CiStatusBuildLogic`: pure status transition and fingerprint logic.
+- `KeycloakSessionService`: experimental browser-based Keycloak/OIDC login recovery.
+- `AuthNotificationCoordinator`: pure decision logic for when auth recovery should show a notification.
+- `LegacySettingsMigration`: migration from older settings and credential keys.
 
-## Authentication Model
+## Runtime Flow
 
-Authentication is handled by `KeycloakSessionService`.
+The normal runtime path is:
 
-There are three levels.
-
-### 1. Background auto-login
-
-Triggered automatically during polling.
-
-```
-recover-auth start → attemptAutoLoginInBackground()
-```
-
-Behavior:
-
-* Uses stored credentials
-* Runs in hidden browser (JCEF)
-* Blocks until result (joins existing attempt if already running)
-
-Result:
-
-* `true` → session recovered
-* `false` → fallback required
-
----
-
-### 2. Interactive login
-
-Triggered only when needed.
-
-```
-ensureLoggedIn()
+```text
+Settings -> Jenkins/GitHub client -> polling -> build logic -> notifications/UI refresh
 ```
 
-Behavior:
+For Jenkins mode:
 
-* Opens browser dialog
-* Autofills credentials
-* User can intervene if needed
-
----
-
-### 3. Notification fallback
-
-Triggered only when auto-login fails.
-
-Managed by `AuthNotificationCoordinator`.
-
-Rules:
-
-* DO NOT show notification if auto-login is running
-* DO NOT show notification if auto-login succeeds
-* SHOW notification only if auto-login fails
-
-Flow:
-
-```
-Auth failure
-  ↓
-attemptAutoLoginInBackground()
-  ↓
-true  → SKIP notification
-false → SHOW notification
+```text
+Settings
+  -> JenkinsStatusClient
+  -> branch/job discovery
+  -> latest build summary
+  -> CiStatusBuildLogic
+  -> notification and Jenkins CI tool window refresh
 ```
 
----
+For GitHub mode:
 
-## Logging
-
-All auth-related behavior is logged via `CiStatusDebugLog`.
-
-Key markers:
-
-```
-recover-auth start
-auto-login requested
-auto-login finished result=...
-auth-notify CHECK
-auth-notify SKIP
-auth-notify SHOW
-auth-notify EMIT
-auth-notify CLICK
+```text
+Settings
+  -> GitShaReader
+  -> GitHubStatusClient
+  -> CiStatusBuildLogic
+  -> IDE notification
 ```
 
-Use logs to understand execution order.
+## Jenkins Artifacts and Preview
 
----
+Artifact handling lives mainly in `JenkinsStatusClient` and `CiStatusToolWindowFactory`.
 
-## Key Components
+The client reads artifact metadata and downloads artifacts for a selected build. The tool window can open HTML report artifacts in an IDE preview when embedded browser support is available. Downloads preserve artifact paths so relative report assets such as CSS, scripts, images, and linked pages can continue to resolve locally.
 
-### KeycloakSessionService
+## Authentication and OIDC
 
-Handles:
+Jenkins API-token access is the preferred authentication model.
 
-* Auto-login
-* Interactive login
-* Credential management
+Some Jenkins installations sit behind Keycloak/OIDC and require a web session before API calls succeed. The experimental auth path is:
 
-Important:
-
+```text
+Jenkins API auth failure
+  -> KeycloakSessionService.attemptAutoLoginInBackground()
+  -> recovered: retry/refresh without notification
+  -> not recovered: AuthNotificationCoordinator may show login action
+  -> interactive fallback if the user chooses it
 ```
-attemptAutoLoginInBackground() joins ongoing attempts
+
+Keep interactive login decisions out of polling code where possible. Polling should go through `AuthNotificationCoordinator` so notification behavior remains testable.
+
+## Build and Run Locally
+
+Use JDK 17.
+
+Run the plugin in a development IDE:
+
+```bash
+./gradlew runIde
 ```
 
----
+Build the plugin ZIP:
 
-### AuthNotificationCoordinator
+```bash
+./gradlew buildPlugin
+```
 
-Encapsulates the decision:
+Run the full local build:
 
-“Should we notify the user?”
+```bash
+./gradlew build
+```
 
-Pure logic:
+Run JetBrains plugin verification:
 
-* Calls auto-login
-* Decides notification
-* No UI dependencies
+```bash
+./gradlew verifyPlugin
+```
 
-Fully testable.
+The configured verifier targets are declared in `build.gradle.kts`.
 
----
+## Tests
 
-### CiStatusStartupActivity / ToolWindow
-
-Entry points:
-
-* Polling
-* UI-triggered actions
-
-They must:
-
-* NEVER directly trigger interactive login
-* ALWAYS go through coordinator logic
-
----
-
-[//]: # (## Testing Strategy)
-
-[//]: # ()
-[//]: # (Tests are pure &#40;no IDE required&#41;.)
-
-[//]: # ()
-[//]: # (Covered cases:)
-
-[//]: # ()
-[//]: # (* Auto-login success → no notification)
-
-[//]: # (* Auto-login failure → notification shown)
-
-[//]: # (* Notification click → interactive login)
-
-[//]: # (* Concurrent auto-login → waits correctly)
-
-[//]: # ()
-[//]: # (---)
-
-
-## Tests and Verification
-
-### Standard test suite
-
-Run the normal test suite with:
+Run the standard test suite:
 
 ```bash
 ./gradlew test
 ```
 
-Smoke tests are skipped by default, so this command is safe for normal local development and for the standard CI test workflow.
-
-For Settings-related tests only:
+Run Settings-focused tests:
 
 ```bash
 ./gradlew test --tests "*CiStatusConfigurable*"
 ```
 
-For a specific test class:
+Run a single test class:
 
 ```bash
 ./gradlew test --tests "*CiStatusConfigurableApplyResetTest"
 ```
 
-### Controlled smoke tests
+The default suite avoids requiring Docker and is suitable for regular local development and CI.
 
-Controlled smoke tests are real integration checks against local, disposable services.
+## Controlled Smoke Tests
 
-They are opt-in and must be enabled explicitly:
+Smoke tests use disposable local services and are opt-in.
+
+Run them only when Docker is available:
 
 ```bash
 JCN_CONTAINER_SMOKE_ENABLED=true ./gradlew test --tests "*SmokeTest"
 ```
 
-Current smoke coverage includes the Jenkins Settings flow:
+The Jenkins Settings smoke test starts a local Jenkins container, creates a known user/job, verifies Settings persistence, and checks successful and failing Jenkins connection diagnostics.
 
-```bash
-JCN_CONTAINER_SMOKE_ENABLED=true ./gradlew test --tests "*CiStatusConfigurableContainerSmokeTest"
-```
+New smoke tests should use the `*SmokeTest` naming convention so the PR smoke workflow can find them.
 
-The controlled Jenkins smoke test:
+## PIT Mutation Testing
 
-* starts a local Jenkins container through Testcontainers
-* uses a Jenkins Docker image configured for the test environment
-* creates a known user and job
-* verifies Settings save/reload
-* verifies the `Test Jenkins connection` action with valid credentials
-* verifies failure reporting with invalid credentials or invalid Jenkins URL
-
-Docker must be available. On local macOS development machines, the test may try to start Docker Desktop if it is installed but not running. If Docker is unavailable, the smoke test should be skipped with a clear message rather than failing unexpectedly.
-
-New smoke test classes should follow this naming convention:
+PIT is configured for pure decision logic classes:
 
 ```text
-*SmokeTest
-```
-
-The PR smoke workflow runs all classes matching this pattern.
-
----
-### PIT Mutation Testing Scripts
-
-The project includes helper scripts for running PIT mutation testing in a controlled way.
-
-PIT is configured in `build.gradle.kts` and currently targets the core classes that contain pure decision logic:
-
-```
 com.damorosodaragona.jenkinsnotifier.CiStatusBuildLogic
 com.damorosodaragona.jenkinsnotifier.AuthNotificationCoordinator
 ```
 
-The default PIT configuration uses a small set of stable tests. For broader mutation analysis, use the scripts in `scripts/`.
-
-#### Discover PIT-safe tests
-
-Run:
+Discover PIT-safe tests:
 
 ```bash
 ./scripts/discover-pit-safe-tests.sh
 ```
 
-This script:
-
-* builds the test classes
-* scans Kotlin test classes under `com.damorosodaragona.jenkinsnotifier`
-* runs PIT once per test class
-* writes safe tests to `build/pit-safe-tests.txt`
-* writes failing or incompatible tests to `build/pit-unsafe-tests.txt`
-* stores detailed logs in `build/pit-discovery-logs/`
-
-A test is considered PIT-safe when PIT can execute it successfully in isolation.
-
-#### Run PIT with safe tests
-
-After discovery, run:
+Run PIT with the safe list:
 
 ```bash
 ./scripts/safe-pitest.sh
 ```
 
-This script reads `build/pit-safe-tests.txt` and passes it to Gradle through:
-
-```bash
--PpitSafeTestsFile=build/pit-safe-tests.txt
-```
-
-The PIT HTML report is generated under:
-
-```
-build/reports/pitest/
-```
-
-#### Run PIT for one test class
-
-For debugging a specific test class, run PIT directly with:
+Run PIT for one test class:
 
 ```bash
 ./gradlew pitest --no-configuration-cache --rerun-tasks -PpitTargetTests=com.damorosodaragona.jenkinsnotifier.SomeTest
 ```
 
-This is useful when deciding whether a test should be included in the safe list.
+Keep PIT focused on pure logic. UI-heavy, IDE-dependent, or unstable tests should stay in the normal JUnit suite rather than the PIT safe list.
 
-#### Contributor rules for PIT
+## Contribution Guidelines
 
-* Keep PIT focused on pure logic classes.
-* Do not add UI-heavy or IDE-dependent tests to the safe PIT list.
-* If a test is unstable under PIT, leave it in `pit-unsafe-tests.txt` and keep it covered by normal JUnit tests.
-* Use PIT as an additional quality check, not as a replacement for regular unit tests.
-
----
-
-### Plugin verifier
-
-Run JetBrains plugin verification with:
-
-```bash
-./gradlew verifyPlugin
-```
-
-The verifier checks the plugin against the IDE targets declared in `build.gradle.kts` under `intellijPlatform.pluginVerification.ides`.
-
-Current verification targets:
-
-```text
-PyCharm Community 2023.3.7
-PyCharm Professional 2023.3.7
-PyCharm Professional 2026.1
-```
-
-`2023.3.7` covers the pre-unified PyCharm model, where Community and Professional are separate IDE products.
-
-`2026.1` covers the newer unified PyCharm distribution model, represented through the PyCharm Professional verifier target in the current Gradle configuration.
-
-Before release, run:
-
-```bash
-./gradlew test
-JCN_CONTAINER_SMOKE_ENABLED=true ./gradlew test --tests "*SmokeTest"
-./gradlew clean buildPlugin
-./gradlew verifyPlugin
-```
----
-
-## Build plugin
-
-To build the plugin ZIP locally:
-
-```bash
-./gradlew clean buildPlugin
-```
-
-The generated plugin artifact is produced under:
-
-```text
-build/distributions/
-```
----
-
-## Rules for Contributors
-
-* Do not bypass `AuthNotificationCoordinator`
-* Do not call `ensureLoggedIn()` directly from polling paths
-* Keep auth logic centralized
-* Add logs for every decision branch
-* Prefer pure, testable logic over UI-coupled code
-
----
-
-## Cleanup Notes
-
-Migration / legacy code:
-
-```
-LegacySettingsMigration*
-```
-
-Can be removed after stable release (1.0.0+).
-
----
-
+- Prefer tests around pure logic before changing UI or polling behavior.
+- Keep Jenkins networking behavior in `JenkinsStatusClient` unless a UI concern genuinely belongs in the tool window.
+- Keep Settings persistence in `CiStatusSettings` and Settings UI wiring in `CiStatusConfigurable`.
+- Keep notification decisions testable through `CiStatusBuildLogic` or `AuthNotificationCoordinator`.
+- Do not store tokens or web passwords in persisted XML state; use the JetBrains Password Safe helpers already present in `CiStatusSettings`.
+- For release work, update `pluginVersion` in `gradle.properties`, verify with `./gradlew clean test verifyPlugin buildPlugin`, then create the annotated release tag only after the release PR is merged.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,59 @@
 # CI Status Notifier
 
-Small PyCharm/IntelliJ plugin that polls GitHub commit statuses for the current Git commit and shows IDE notifications when CI status changes.
+CI Status Notifier is a PyCharm/IntelliJ plugin that keeps the current project's CI state visible inside the IDE.
 
-It is designed for repositories where Jenkins publishes commit statuses to GitHub, so the IDE does not need direct Jenkins access or a Jenkins plugin.
+It can read GitHub commit statuses or query Jenkins directly, then shows notifications when the build changes state. In Jenkins mode it also adds a **Jenkins CI** tool window with the detected job, latest build status, Pipeline stages, build artifacts, and HTML report previews when embedded browser rendering is available.
 
-## Local Development
+## Configure the Plugin
 
-Open this folder as a Gradle project in PyCharm or IntelliJ IDEA:
+Open:
 
-```bash
-ide-plugins/ci-status-notifier
+```text
+Settings | Tools | Jenkins CI Notifier
 ```
 
-Useful Gradle tasks:
+Enable **Poll CI statuses**, choose a provider, then fill in the fields for your setup.
 
-```bash
-./gradlew runIde
-./gradlew buildPlugin
-```
+### GitHub Status Mode
 
-If the Gradle wrapper is not present, import the project in the IDE and let JetBrains create/use a Gradle runtime, or install Gradle locally.
+Use this when Jenkins or another CI service publishes commit statuses to GitHub.
 
-## Installation from ZIP
+- **GitHub repository**: repository in `owner/name` format.
+- **GitHub token**: optional, but recommended for private repositories or frequent polling.
+- **Poll interval seconds**: how often the plugin checks for status changes.
+- **Notifications**: choose whether pending, successful, and failed/error statuses should trigger IDE notifications.
+
+### Jenkins Mode
+
+Use this when the plugin should talk to Jenkins directly.
+
+- **Jenkins URL**: base URL for your Jenkins instance.
+- **Jenkins scan root**: optional path used to narrow job discovery. Leave it blank to scan from the Jenkins root, use a raw path such as `job/Folder/job/project`, or use a slash-separated path such as `Folder/project`.
+- **Jenkins username** and **Jenkins API token**: optional credentials for Jenkins API access.
+- **Test Jenkins connection**: checks the current Settings values and reports what the plugin can reach.
+- **Poll interval seconds** and **Notifications**: control polling cadence and notification types.
+
+Jenkins mode tries to match the current Git branch to the best Jenkins job. If automatic detection is not enough, the tool window still shows the Jenkins job tree so you can select a job manually.
+
+## Authentication
+
+Tokens and web passwords are stored in the JetBrains Password Safe.
+
+The recommended Jenkins setup is API access with a Jenkins API token that does not require an active browser/OIDC session.
+
+If your Jenkins instance requires Keycloak or another OIDC web session, the plugin includes experimental options:
+
+- **Keycloak interactive login fallback** opens a browser login flow when API access fails.
+- **Keycloak auto-login** tries to restore the web session in the background using stored web credentials.
+- **Keycloak authentication debug log** adds diagnostic log entries for auth troubleshooting.
+
+These options are experimental because OIDC and Jenkins gateway behavior can vary by server and IDE version.
+
+## Artifacts and Preview
+
+When Jenkins mode finds a build, the tool window can list artifacts for that build. HTML report artifacts can be opened in an IDE preview when supported. The plugin downloads the selected build's artifacts into the IDE cache while preserving relative paths, so linked CSS, scripts, images, and report pages can render locally.
+
+## Install from ZIP
 
 Build the plugin ZIP:
 
@@ -29,54 +61,22 @@ Build the plugin ZIP:
 ./gradlew buildPlugin
 ```
 
-The generated ZIP is created under:
+The ZIP is created under:
 
 ```text
 build/distributions/
 ```
 
-You can also download the ZIP from the latest GitHub Release:
-
-```text
-https://github.com/damorosodaragona/ci-status-notifier-PyCharm-plugin/releases/latest
-```
-
-Install it in PyCharm or IntelliJ IDEA:
+Install it from the IDE:
 
 1. Open `Settings | Plugins`.
 2. Click the gear icon.
 3. Select `Install Plugin from Disk...`.
-4. Choose the ZIP file from `build/distributions/` or from the GitHub Release assets.
-5. Restart the IDE when prompted.
+4. Choose the ZIP from `build/distributions/`.
+5. Restart the IDE if prompted.
 
-## Configuration
-
-After installing/running the plugin:
+You can also use the latest GitHub Release when one is available:
 
 ```text
-Settings | Tools | CI Status Notifier
+https://github.com/damorosodaragona/ci-status-notifier-PyCharm-plugin/releases/latest
 ```
-
-Configure GitHub status mode:
-
-- GitHub repository in `owner/name` format.
-- Optional GitHub token. Required for private repositories or high polling frequency.
-- Poll interval in seconds.
-
-Configure Jenkins mode:
-
-- Jenkins base URL.
-- Optional Jenkins scan root. Leave blank to scan from the Jenkins root, or set a raw (`job/Folder/job/project`) or slash-separated (`Folder/project`) path to narrow the scan. Root scans require Jenkins permissions that allow reading the global Jenkins root.
-- Optional Jenkins username and API token.
-- Poll interval in seconds.
-
-Some Jenkins instances require an active web session (Keycloak / OIDC) to allow API access.
-
-**Recommended solution:**  
-Enable API access without requiring an OIDC session on the Jenkins server.
-
-If that is not possible and you are using Keycloak, you can try enabling the **experimental Keycloak auto-login** feature in the plugin settings.
-
-Jenkins mode adds a `CI Status` tool window that scans the configured Jenkins root, auto-selects the build job that best matches the current Git branch, and still shows the Jenkins job tree as a manual fallback. Selecting a job shows its latest build, Pipeline stages, artifacts, and an in-IDE preview for HTML report artifacts when the IDE supports embedded browser rendering. HTML previews download all artifacts for the selected build into the IDE cache while preserving artifact paths, so linked CSS, scripts, images, and relative links keep working locally.
-
-Tokens are stored in the JetBrains Password Safe.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,31 @@
+# Release Notes
+
+## v1.0.0
+
+This is the first stable MVP release of Jenkins CI Notifier.
+
+### Highlights
+
+- Poll GitHub commit statuses for the current Git commit.
+- Query Jenkins directly and display the selected job in the Jenkins CI tool window.
+- Match Jenkins jobs against the current Git branch, with a manual job-tree fallback.
+- Show latest build state, Pipeline stages, and build artifacts.
+- Preview HTML report artifacts inside the IDE when embedded browser support is available.
+- Configure GitHub and Jenkins providers from `Settings | Tools | Jenkins CI Notifier`.
+- Store GitHub, Jenkins, and Keycloak credentials in the JetBrains Password Safe.
+- Provide experimental Keycloak/OIDC interactive login and auto-login support for Jenkins installations that require a web session.
+
+### Verification
+
+Before tagging the release, run:
+
+```bash
+./gradlew clean test verifyPlugin buildPlugin
+```
+
+Then create the annotated tag after the release PR is merged:
+
+```bash
+git tag -a v1.0.0 -m "Release v1.0.0"
+git push origin v1.0.0
+```

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 pluginGroup=com.damorosodaragona.jenkinsnotifier
 pluginName=Jenkins CI Notifier
 pluginRepositoryUrl=https://github.com/damorosodaragona/jenkins-ci-notifier
-pluginVersion=0.6.1
+pluginVersion=1.0.0
 
 platformType=PC
 platformVersion=2023.3.7

--- a/src/main/kotlin/com/damorosodaragona/jenkinsnotifier/KeycloakSessionService.kt
+++ b/src/main/kotlin/com/damorosodaragona/jenkinsnotifier/KeycloakSessionService.kt
@@ -179,7 +179,7 @@ class KeycloakSessionService(private val project: Project) : Disposable {
             val accepted = dialog.showAndGet()
             autofillTimer?.stop()
             val finalUrl = browser.cefBrowser.url.orEmpty()
-            result[0] = accepted && finalUrl.startsWith(baseUrl) && !looksLikeLogin(finalUrl)
+            result[0] = isInteractiveLoginSuccessful(accepted, baseUrl, finalUrl)
             log("interactive-login closed accepted=$accepted finalUrl=$finalUrl result=${result[0]}")
             finished.countDown()
         }
@@ -382,7 +382,7 @@ class KeycloakSessionService(private val project: Project) : Disposable {
                 return;
               }
 
-              if (current.startsWith('${jsString(baseUrl)}') && current.indexOf('commenceLogin') === -1) {
+              if (current.startsWith('${jsString(baseUrl)}') && !/(securityRealm|commenceLogin|finishLogin|loginError)/i.test(current)) {
                 window.__ciStatusProbeRunning = true;
                 log('on Jenkins origin; starting API probe url=${jsString(probeUrl)}');
                 fetch('${jsString(probeUrl)}', {
@@ -434,9 +434,19 @@ class KeycloakSessionService(private val project: Project) : Disposable {
     """.trimIndent()
 
     private fun looksLikeLogin(url: String): Boolean =
-        url.contains("commenceLogin", ignoreCase = true) ||
+        url.contains("securityRealm", ignoreCase = true) ||
+            url.contains("commenceLogin", ignoreCase = true) ||
+            url.contains("finishLogin", ignoreCase = true) ||
+            url.contains("loginError", ignoreCase = true) ||
             url.contains("keycloak", ignoreCase = true) ||
             url.contains("login-actions", ignoreCase = true)
+
+    private fun isInteractiveLoginSuccessful(accepted: Boolean, baseUrl: String, finalUrl: String): Boolean {
+        val normalizedBaseUrl = baseUrl.trim().trimEnd('/')
+        return accepted &&
+            finalUrl.startsWith(normalizedBaseUrl, ignoreCase = true) &&
+            !looksLikeLogin(finalUrl)
+    }
 
     private fun jsString(value: String): String =
         value.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n").replace("\r", "")

--- a/src/test/kotlin/com/damorosodaragona/jenkinsnotifier/CiStatusConfigurableUiSmokeTest.kt
+++ b/src/test/kotlin/com/damorosodaragona/jenkinsnotifier/CiStatusConfigurableUiSmokeTest.kt
@@ -1,0 +1,86 @@
+package com.damorosodaragona.jenkinsnotifier
+
+import org.junit.jupiter.api.Tag
+import javax.swing.JButton
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@Tag("smoke")
+class CiStatusConfigurableUiSmokeTest {
+    @Test
+    fun `settings UI preserves provider-specific input while switching panels`() = withTestPasswordSafe {
+        val settings = CiStatusSettings()
+        val configurable = CiStatusConfigurable(projectWithSettings(settings))
+
+        configurable.createComponent()
+
+        assertEquals("github", configurable.comboBox("provider").selectedItem)
+        assertTrue(configurable.component("githubSettingsPanel").isVisible)
+        assertFalse(configurable.component("jenkinsSettingsPanel").isVisible)
+
+        configurable.textField("repository").text = " damorosodaragona/ci-status-notifier-PyCharm-plugin "
+        configurable.passwordField("token").text = "github-token"
+        configurable.checkBox("notifyPending").isSelected = true
+        configurable.checkBox("notifySuccess").isSelected = true
+        configurable.checkBox("notifyFailure").isSelected = false
+
+        configurable.comboBox("provider").selectedItem = "jenkins"
+
+        assertFalse(configurable.component("githubSettingsPanel").isVisible)
+        assertTrue(configurable.component("jenkinsSettingsPanel").isVisible)
+        assertEquals(" damorosodaragona/ci-status-notifier-PyCharm-plugin ", configurable.textField("repository").text)
+        assertEquals("github-token", String(configurable.passwordField("token").password))
+
+        configurable.textField("jenkinsBaseUrl").text = " https://jenkins.example.org/ "
+        configurable.textField("jenkinsJobPath").text = " /Folder/project/ "
+        configurable.textField("jenkinsUsername").text = " robot "
+        configurable.passwordField("jenkinsToken").text = "jenkins-token"
+        configurable.checkBox("experimentalKeycloakInteractiveFallback").isSelected = true
+        configurable.checkBox("experimentalKeycloakAutoLogin").isSelected = true
+        configurable.checkBox("experimentalKeycloakDebug").isSelected = true
+        configurable.textField("keycloakWebUsername").text = " oidc-user "
+        configurable.passwordField("keycloakWebPassword").text = "oidc-password"
+        configurable.textField("pollInterval").text = "45"
+
+        assertTrue(configurable.button("testJenkinsButton").isVisible)
+        assertTrue(configurable.isModified())
+
+        configurable.apply()
+
+        assertEquals("jenkins", settings.provider)
+        assertEquals("damorosodaragona/ci-status-notifier-PyCharm-plugin", settings.repository)
+        assertEquals("github-token", settings.getToken())
+        assertEquals("https://jenkins.example.org", settings.jenkinsBaseUrl)
+        assertEquals("Folder/project", settings.jenkinsJobPath)
+        assertEquals("robot", settings.jenkinsUsername)
+        assertEquals("jenkins-token", settings.getJenkinsToken())
+        assertTrue(settings.experimentalKeycloakInteractiveFallback)
+        assertTrue(settings.experimentalKeycloakAutoLogin)
+        assertTrue(settings.experimentalKeycloakDebug)
+        assertEquals("oidc-user", settings.keycloakWebUsername)
+        assertEquals("oidc-password", settings.getKeycloakWebPassword())
+        assertEquals(45, settings.pollIntervalSeconds)
+        assertTrue(settings.notifyPending)
+        assertTrue(settings.notifySuccess)
+        assertFalse(settings.notifyFailure)
+
+        val reloaded = CiStatusConfigurable(projectWithSettings(settings))
+        reloaded.createComponent()
+
+        assertEquals("jenkins", reloaded.comboBox("provider").selectedItem)
+        assertFalse(reloaded.component("githubSettingsPanel").isVisible)
+        assertTrue(reloaded.component("jenkinsSettingsPanel").isVisible)
+        assertEquals("https://jenkins.example.org", reloaded.textField("jenkinsBaseUrl").text)
+        assertEquals("Folder/project", reloaded.textField("jenkinsJobPath").text)
+        assertEquals("robot", reloaded.textField("jenkinsUsername").text)
+        assertEquals("jenkins-token", String(reloaded.passwordField("jenkinsToken").password))
+        assertEquals("oidc-user", reloaded.textField("keycloakWebUsername").text)
+        assertEquals("oidc-password", String(reloaded.passwordField("keycloakWebPassword").password))
+        assertFalse(reloaded.isModified())
+    }
+
+    private fun CiStatusConfigurable.button(name: String): JButton =
+        privateField(name)
+}

--- a/src/test/kotlin/com/damorosodaragona/jenkinsnotifier/KeycloakSessionServiceReflectionTest.kt
+++ b/src/test/kotlin/com/damorosodaragona/jenkinsnotifier/KeycloakSessionServiceReflectionTest.kt
@@ -12,9 +12,45 @@ class KeycloakSessionServiceReflectionTest {
         val service = KeycloakSessionService(project = projectWithServiceStub())
 
         assertTrue(service.looksLikeLoginForTest("https://jenkins.example.org/securityRealm/commenceLogin"))
+        assertTrue(service.looksLikeLoginForTest("https://jenkins.example.org/securityRealm/finishLogin"))
+        assertTrue(service.looksLikeLoginForTest("https://jenkins.example.org/securityRealm/loginError"))
         assertTrue(service.looksLikeLoginForTest("https://id.example.org/keycloak/realms/test/protocol/openid-connect/auth"))
         assertTrue(service.looksLikeLoginForTest("https://id.example.org/realms/test/login-actions/authenticate"))
         assertFalse(service.looksLikeLoginForTest("https://jenkins.example.org/job/projector/lastBuild/api/json"))
+    }
+
+    @Test
+    fun `interactive login rejects Jenkins error and login callback URLs`() {
+        val service = KeycloakSessionService(project = projectWithServiceStub())
+
+        assertFalse(
+            service.interactiveLoginSuccessfulForTest(
+                accepted = true,
+                baseUrl = "https://jenkins.example.org",
+                finalUrl = "https://jenkins.example.org/securityRealm/finishLogin",
+            ),
+        )
+        assertFalse(
+            service.interactiveLoginSuccessfulForTest(
+                accepted = true,
+                baseUrl = "https://jenkins.example.org",
+                finalUrl = "https://jenkins.example.org/securityRealm/loginError",
+            ),
+        )
+        assertFalse(
+            service.interactiveLoginSuccessfulForTest(
+                accepted = false,
+                baseUrl = "https://jenkins.example.org",
+                finalUrl = "https://jenkins.example.org/",
+            ),
+        )
+        assertTrue(
+            service.interactiveLoginSuccessfulForTest(
+                accepted = true,
+                baseUrl = "https://jenkins.example.org",
+                finalUrl = "https://jenkins.example.org/",
+            ),
+        )
     }
 
     @Test
@@ -53,5 +89,20 @@ class KeycloakSessionServiceReflectionTest {
         val method = KeycloakSessionService::class.java.getDeclaredMethod("jsString", String::class.java)
         method.isAccessible = true
         return method.invoke(this, value) as String
+    }
+
+    private fun KeycloakSessionService.interactiveLoginSuccessfulForTest(
+        accepted: Boolean,
+        baseUrl: String,
+        finalUrl: String,
+    ): Boolean {
+        val method = KeycloakSessionService::class.java.getDeclaredMethod(
+            "isInteractiveLoginSuccessful",
+            Boolean::class.javaPrimitiveType,
+            String::class.java,
+            String::class.java,
+        )
+        method.isAccessible = true
+        return method.invoke(this, accepted, baseUrl, finalUrl) as Boolean
     }
 }


### PR DESCRIPTION
## Summary

Closes #6.
Closes #7.
Closes #12.
Closes #13.
Closes #16.
Closes #28.

Release: v1.0.0

This PR completes the MVP stabilization queue for the first stable release.

## Changes

- Refresh README for end users: configuration, GitHub/Jenkins modes, authentication, artifacts, preview, and installation.
- Expand CONTRIBUTING for maintainers: project layout, component responsibilities, runtime flow, build/run/test commands, smoke tests, PIT, and release guidance.
- Update `pluginVersion` to `1.0.0` and add `RELEASE_NOTES.md` for the stable MVP release.
- Tighten experimental Keycloak/OIDC login detection so Jenkins `securityRealm` callback/error URLs are not treated as successful interactive logins.
- Add settings UI smoke coverage for provider switching and persisted UI state.
- Fix the PR smoke workflow `changes` job so docs-only detection actually produces the outputs consumed by the controlled smoke test job.
- Record the clean-build verification for #7.

## Verification

- `./gradlew test`
- `./gradlew build`
- `./gradlew clean compileKotlin`
- `./gradlew test --tests '*KeycloakSessionServiceReflectionTest'`
- `./gradlew test --tests '*Keycloak*' --tests '*AuthNotificationCoordinator*' --tests '*JenkinsStatusClient*'`
- `./gradlew test --tests '*CiStatusConfigurableUiSmokeTest' --tests '*CiStatusConfigurableApplyResetTest'`
- `./gradlew test --tests '*SmokeTest'`
- `./gradlew buildPlugin`
- `./gradlew clean test verifyPlugin buildPlugin`

## Plugin verifier

Compatible:

- PyCharm Community 2023.3.7 (`PC-233.15619.17`)
- PyCharm Professional 2023.3.7 (`PY-233.15619.17`)
- PyCharm Professional 2026.1 (`PY-261.22158.340`)

Existing deprecated/scheduled-for-removal API usages remain reported by the verifier and are not blockers for this MVP release.
