### PR TITLE
Release v1.0.1 logo update

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## v1.0.1
+
+- Update the plugin logo with a cleaner minimal SVG icon for Marketplace and IDE plugin listings.
+
 ## v1.0.0
 
 This is the first stable MVP release of Jenkins CI Notifier.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 pluginGroup=com.damorosodaragona.jenkinsnotifier
 pluginName=Jenkins CI Notifier
 pluginRepositoryUrl=https://github.com/damorosodaragona/jenkins-ci-notifier
-pluginVersion=1.0.0
+pluginVersion=1.0.1
 
 platformType=PC
 platformVersion=2023.3.7


### PR DESCRIPTION
## Summary

Release: v1.0.1

- Update the plugin logo with a cleaner minimal SVG icon.
- Bump `pluginVersion` to `1.0.1` so the release artifact is produced as `jenkins-ci-notifier-1.0.1.zip`.
- Add v1.0.1 release notes.

## Verification

- `./gradlew buildPlugin`
- Confirmed `build/distributions/jenkins-ci-notifier-1.0.1.zip` contains `META-INF/pluginIcon.svg` inside `jenkins-ci-notifier-1.0.1.jar`.
