### PR TITLE
ci: fix docs-only detection and add license

### DIFF
--- a/.github/actions/detect-docs-only/action.yml
+++ b/.github/actions/detect-docs-only/action.yml
@@ -20,9 +20,13 @@ runs:
       run: |
         set -euo pipefail
 
-        # Default fail-safe: run everything
-        echo "docs_only=false" >> "$GITHUB_OUTPUT"
-        echo "docs_changed=false" >> "$GITHUB_OUTPUT"
+        docs_only=false
+        docs_changed=false
+
+        finish() {
+          echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
+          echo "docs_changed=$docs_changed" >> "$GITHUB_OUTPUT"
+        }
 
         if [ "${{ github.event_name }}" = "push" ]; then
           BASE="${{ github.event.before }}"
@@ -30,17 +34,20 @@ runs:
           BASE="${{ github.event.pull_request.base.sha }}"
         else
           echo "Unsupported event: ${{ github.event_name }}"
+          finish
           exit 0
         fi
 
         # New branch / invalid base / shallow checkout issue => fail-safe
         if [ -z "$BASE" ] || echo "$BASE" | grep -qE '^0+$'; then
           echo "Cannot determine base SHA safely"
+          finish
           exit 0
         fi
 
         if ! git cat-file -e "$BASE^{commit}" 2>/dev/null; then
           echo "Base commit not available locally: $BASE"
+          finish
           exit 0
         fi
 
@@ -48,23 +55,25 @@ runs:
 
         if [ -z "$CHANGED" ]; then
           echo "No changed files detected"
+          finish
           exit 0
         fi
 
         echo "Changed files:"
         echo "$CHANGED"
 
-        DOCS="$(echo "$CHANGED" | grep -E '^docs/|\.md$|\.mdx$' || true)"
-        NON_DOCS="$(echo "$CHANGED" | grep -vE '^docs/|\.md$|\.mdx$' || true)"
+        DOCS="$(echo "$CHANGED" | grep -E '^docs/|\.md$|\.mdx$|^(LICENSE|LICENSE\\..*|COPYING|COPYING\\..*)$' || true)"
+        NON_DOCS="$(echo "$CHANGED" | grep -vE '^docs/|\.md$|\.mdx$|^(LICENSE|LICENSE\\..*|COPYING|COPYING\\..*)$' || true)"
 
         if [ -n "$DOCS" ]; then
-          echo "docs_changed=true" >> "$GITHUB_OUTPUT"
+          docs_changed=true
         fi
 
         if [ -z "$NON_DOCS" ]; then
-          echo "docs_only=true" >> "$GITHUB_OUTPUT"
+          docs_only=true
           echo "Docs-only change detected"
         else
-          echo "docs_only=false" >> "$GITHUB_OUTPUT"
           echo "Non-docs changes detected"
         fi
+
+        finish

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Dario Amoroso d'Aragona
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- Add an MIT `LICENSE` file so GitHub can detect the repository license and the README license badge no longer shows `not specified`.
- Make the docs-only detector deterministic by emitting each output once at the end instead of writing fallback values and then overriding them.
- Treat root `LICENSE` / `COPYING` files as docs-only inputs.

## Notes

This PR changes the docs-only GitHub Action itself, so the Kotlin/JUnit workflow may still run for this PR. The fix is intended to make future README/LICENSE-only PRs skip Kotlin/JUnit correctly.

## Verification

- Reviewed `.github/actions/detect-docs-only/action.yml` output flow locally.
- Reviewed `LICENSE` text locally.
